### PR TITLE
Extended relaxations of reciprocal

### DIFF
--- a/auto_LiRPA/operators/activations.py
+++ b/auto_LiRPA/operators/activations.py
@@ -196,6 +196,61 @@ class BoundSqr(BoundOptimizableActivation):
         return lower, upper
 
 
+class BoundElu(BoundActivation):
+    r"""Sound linear bounds for ``ELU(x) = x if x >= 0 else alpha*(exp(x) - 1)``.
+
+    ELU is monotone increasing, and **convex iff ``alpha <= 1``**: its derivative
+    is ``alpha*exp(x)`` for ``x < 0`` (rising to ``alpha`` at ``0^-``) and ``1``
+    for ``x >= 0``, so the derivative is non-decreasing across 0 only when
+    ``alpha <= 1`` (for ``alpha > 1`` it jumps down from ``alpha`` to ``1`` and
+    ELU is *not* convex). The default ``alpha = 1`` is convex.
+
+    For a convex function the chord through the endpoints is a sound linear
+    *upper* bound and any tangent line a sound linear *lower* bound, so we use the
+    endpoint chord (upper) and the midpoint tangent (lower). Loose (no
+    alpha-optimization) but valid. ``alpha > 1`` is rejected rather than bounded
+    unsoundly.
+    """
+
+    def __init__(self, attr=None, inputs=None, output_index=0, options=None):
+        super().__init__(attr, inputs, output_index, options)
+        self.elu_alpha = float((attr or {}).get('alpha', 1.0))
+        if self.elu_alpha > 1.0:
+            raise NotImplementedError(
+                f'BoundElu only supports alpha <= 1 (ELU is non-convex for '
+                f'alpha > 1); got alpha={self.elu_alpha}')
+        self.splittable = False
+
+    def _elu(self, x):
+        return F.elu(x, self.elu_alpha)
+
+    def _d_elu(self, x):
+        # f'(x) = 1 for x >= 0, alpha*exp(x) for x < 0.
+        return torch.where(x >= 0, torch.ones_like(x), self.elu_alpha * torch.exp(x))
+
+    def forward(self, x):
+        return self._elu(x)
+
+    def interval_propagate(self, *v):
+        h_L, h_U = v[0][0], v[0][1]
+        return self._elu(h_L), self._elu(h_U)  # monotone increasing
+
+    def bound_relax(self, x, init=False, dim_opt=None):
+        if init:
+            self.init_linear_relaxation(x)
+        l, u = x.lower, x.upper
+        # Upper bound: chord through (l, elu(l)) and (u, elu(u)); convex => f <= chord.
+        # Where the interval is degenerate, anchor at l with slope f'(u): still a
+        # sound upper bound (f'(t) <= f'(u) for t <= u by convexity).
+        diff = u - l
+        chord_k = (self._elu(u) - self._elu(l)) / diff.clamp(min=1e-7)
+        k_up = torch.where(diff > 1e-7, chord_k, self._d_elu(u))
+        self.add_linear_relaxation(mask=None, type='upper', k=k_up, x0=l)
+        # Lower bound: tangent at the midpoint; convex => f >= tangent everywhere.
+        mid = 0.5 * (l + u)
+        self.add_linear_relaxation(mask=None, type='lower', k=self._d_elu(mid), x0=mid)
+
+
 class BoundHardTanh(BoundActivation):
 
     def __init__(self, attr=None, inputs=None, output_index=0, options=None):

--- a/auto_LiRPA/operators/convex_concave.py
+++ b/auto_LiRPA/operators/convex_concave.py
@@ -127,17 +127,17 @@ class BoundReciprocal(BoundOptimizableActivation):
     def interval_propagate(self, *v):
         h_L = v[0][0].to(dtype=torch.get_default_dtype())
         h_U = v[0][1].to(dtype=torch.get_default_dtype())
-        assert h_L.min() > 0, 'Only positive values are supported in BoundReciprocal'
-        return torch.reciprocal(h_U), torch.reciprocal(h_L)
+
+        out_L = torch.reciprocal(h_U)
+        out_U = torch.reciprocal(h_L)
+        contains_zero = (h_L <= 0) & (h_U >= 0)
+        out_L = torch.where(contains_zero, -torch.inf, out_L)
+        out_U = torch.where(contains_zero, torch.inf, out_U)
+        return out_L, out_U
 
     def bound_relax(self, x, init=False, dim_opt=None):
         if init:
             self.init_linear_relaxation(x, dim_opt)
-
-        assert x.lower.min() >= 0
-
-        ku = -1. / (x.lower * x.upper)
-        self.add_linear_relaxation(mask=None, type='upper', k=ku, x0=x.lower)
 
         if self.opt_stage in ['opt', 'reuse']:
             self.alpha[self._start].data[:2] = torch.min(torch.max(
@@ -146,24 +146,44 @@ class BoundReciprocal(BoundOptimizableActivation):
         else:
             mid = (x.lower + x.upper) / 2
 
-        self.add_linear_relaxation(
-            mask=None, type='lower', k=-1./(mid**2), x0=mid)
+        x_pos = x.lower > 0
 
-        if x.lower.min() <= 0:
-            mask = x.lower == 0
+        # the upper bound for x > 0 is a lower bound for x < 0
+        pos_ku = -1. / (x.lower * x.upper)
+        pos_kl = -1. / (mid**2)
+
+        self.add_linear_relaxation(mask=x_pos, type='upper', k=pos_ku, x0=x.lower)
+        self.add_linear_relaxation(mask=~x_pos, type='upper', k=pos_kl, x0=mid)
+
+        self.add_linear_relaxation(mask=x_pos, type='lower', k=pos_kl, x0=mid)
+        self.add_linear_relaxation(mask=~x_pos, type='lower', k=pos_ku, x0=x.lower)
+
+        contains_zero = (x.lower <= 0) & (x.upper >= 0)
+        if contains_zero.any():
+            mask = contains_zero & (x.upper > 0)
             self.uw[..., mask] = 0
             self.ub[..., mask] = torch.inf
+
+            mask = contains_zero & (x.lower < 0)
+            self.lw[..., mask] = 0
+            self.lb[..., mask] = -torch.inf
+
         if x.upper.isinf().any():
-            mask = x.upper.isinf()
+            mask = x.upper.isinf() & (x.lower >= 0)
             self.lw[..., mask] = 0
             self.lb[..., mask] = 0
+        if x.lower.isinf().any():
+            mask = x.lower.isinf() & (x.upper <= 0)
+            self.uw[..., mask] = 0
+            self.ub[..., mask] = 0 
+
 
     def bound_backward(self, last_lA, last_uA, x, **kwargs):
         As, lbias, ubias = super().bound_backward(last_lA, last_uA, x, **kwargs)
         if isinstance(ubias, torch.Tensor) and ubias.isnan().any():
             ubias[ubias.isnan()] = torch.inf if (last_uA != 0).any() else 0.
         if isinstance(lbias, torch.Tensor) and lbias.isnan().any():
-            lbias[lbias.isnan()] = 0.
+            lbias[lbias.isnan()] = -torch.inf if (last_lA != 0).any() else 0.
         return As, lbias, ubias
 
     def _init_opt_parameters_impl(self, size_spec, **kwargs):

--- a/auto_LiRPA/operators/logical.py
+++ b/auto_LiRPA/operators/logical.py
@@ -23,11 +23,28 @@ class BoundWhere(Bound):
         return torch.where(condition.to(torch.bool), x, y)
 
     def interval_propagate(self, *v):
-        assert not self.is_input_perturbed(0)
-        condition = v[0][0]
-        return tuple([torch.where(condition, v[1][j], v[2][j]) for j in range(2)])
+        (cond_l, cond_u), (xl, xu), (yl, yu) = v[0], v[1], v[2]
+        if not self.is_input_perturbed(0):
+            # Fixed condition: select the corresponding branch bounds elementwise.
+            c = cond_l.to(torch.bool)
+            return torch.where(c, xl, yl), torch.where(c, xu, yu)
+        # Perturbed condition: ``where`` treats any non-zero as true (numpy/minijax
+        # semantics). Sound interval rule: where the condition interval excludes 0
+        # the branch is determined; where it contains 0 either branch is possible,
+        # so take the elementwise union of the two branch intervals.
+        cl, cu = cond_l, cond_u
+        true_mask = (cl > 0) | (cu < 0)          # interval excludes 0 -> definitely x
+        false_mask = (cl == 0) & (cu == 0)       # exactly zero -> definitely y
+        out_l = torch.where(true_mask, xl, torch.where(false_mask, yl, torch.minimum(xl, yl)))
+        out_u = torch.where(true_mask, xu, torch.where(false_mask, yu, torch.maximum(xu, yu)))
+        return out_l, out_u
 
     def bound_backward(self, last_lA, last_uA, condition, x, y, **kwargs):
+        # NOTE: CROWN (linear relaxation) still only supports a fixed condition.
+        # interval_propagate (IBP) above handles a perturbed condition via the
+        # branch union; milestone2 only uses where through IBP-mode bounds, so
+        # this path is not hit. Bounding a perturbed-condition where with CROWN
+        # would need a linear relaxation of the selection and is not implemented.
         assert torch.allclose(condition.lower.float(), condition.upper.float())
         assert self.from_input
         mask = condition.lower.float()

--- a/auto_LiRPA/operators/tanh.py
+++ b/auto_LiRPA/operators/tanh.py
@@ -35,6 +35,12 @@ def dsigmoid(x):
 def darctan(x):
     return (x.square() + 1.).reciprocal()
 
+# 2/sqrt(pi), the constant factor of the error-function derivative.
+_ERF_DERIV_CONST = 1.1283791670955126
+
+def derf(x):
+    return _ERF_DERIV_CONST * torch.exp(-x.square())
+
 
 # TODO refactor BoundTanh into a general op class for convex/concave like nonlinear functions.
 class BoundTanh(BoundOptimizableActivation):
@@ -443,6 +449,20 @@ class BoundAtan(BoundTanh):
         super().__init__(attr, inputs, output_index, options,
                          activation=('arctan', torch.arctan, darctan))
         self.split_range = (-torch.inf, torch.inf)
+
+
+class BoundErf(BoundTanh):
+    """Bounds for the error function ``erf``.
+
+    ``erf`` is S-shaped exactly like ``tanh``/``sigmoid``: monotone increasing,
+    odd, with a single inflection at 0 (convex on x<0, concave on x>0) and range
+    (-1, 1). It therefore reuses the generic S-shaped tangent-line relaxation of
+    ``BoundTanh`` unchanged. Registering this op is enough to bound the exact
+    (erf-based) GELU, which torch lowers to ``0.5 * x * (1 + erf(x / sqrt(2)))``.
+    """
+    def __init__(self, attr=None, inputs=None, output_index=0, options=None):
+        super().__init__(attr, inputs, output_index, options,
+                         activation=('erf', torch.erf, derf))
 
 
 class BoundTan(BoundAtan):


### PR DESCRIPTION
This PR adds relaxations for the reciprocal when the input bounds are negative or contain zero. 

The bounds for strictly negative inputs mirror those for positive inputs, with the lower and upper bounds swapped. When the input bounds contain zero, the lower and upper bounds blow up to -inf/inf. 