### PR TITLE
Add atomic SiLU support and tests

### DIFF
--- a/auto_LiRPA/bound_op_map.py
+++ b/auto_LiRPA/bound_op_map.py
@@ -28,6 +28,7 @@ bound_op_map = {
     'grad::Tanh': BoundTanhGrad,
     'grad::Sigmoid': BoundSigmoidGrad,
     'custom::Gelu': BoundGelu,
+    'custom::SiLU': BoundSiLU,
     'onnx::Clip': BoundHardTanh
 }
 

--- a/auto_LiRPA/operators/__init__.py
+++ b/auto_LiRPA/operators/__init__.py
@@ -45,4 +45,5 @@ from .reshape import *
 from .minmax import *
 from .convex_concave import *
 from .gelu import *
+from .silu import *
 from .tile import *

--- a/auto_LiRPA/operators/silu.py
+++ b/auto_LiRPA/operators/silu.py
@@ -1,0 +1,266 @@
+#########################################################################
+##   This file is part of the auto_LiRPA library, a core part of the   ##
+##   α,β-CROWN (alpha-beta-CROWN) neural network verifier developed    ##
+##   by the α,β-CROWN Team                                             ##
+##                                                                     ##
+##   Copyright (C) 2020-2025 The α,β-CROWN Team                        ##
+##   Team leaders:                                                     ##
+##          Faculty:   Huan Zhang <huan@huan-zhang.com> (UIUC)         ##
+##          Student:   Xiangru Zhong <xiangru4@illinois.edu> (UIUC)    ##
+##                                                                     ##
+##   See CONTRIBUTORS for all current and past developers in the team. ##
+##                                                                     ##
+##     This program is licensed under the BSD 3-Clause License,        ##
+##        contained in the LICENCE file in this directory.             ##
+##                                                                     ##
+#########################################################################
+"""SiLU support."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .activation_base import BoundActivation
+
+
+_SILU_X_MIN = -1.2784645427610737
+_SILU_INFLECTION = 2.3993572805154675
+
+
+def silu(x):
+    return x * torch.sigmoid(x)
+
+
+def dsilu(x):
+    """First derivative of SiLU."""
+    sig = torch.sigmoid(x)
+    return sig * (1 + x * (1 - sig))
+
+
+def d2silu(x):
+    """Second derivative of SiLU."""
+    sig = torch.sigmoid(x)
+    return sig * (1 - sig) * (2 + x * (1 - 2 * sig))
+
+
+class BoundSiLU(BoundActivation):
+    """
+    SiLU as an atomic unary activation.
+
+    This atomic version focuses on two things:
+    1. exact interval propagation using the internal minimum point;
+    2. tighter single-line relaxations on pure convex/concave intervals, with
+       a conservative fallback on mixed-curvature intervals.
+    """
+    def __init__(self, attr=None, inputs=None, output_index=0, options=None):
+        super().__init__(attr, inputs, output_index, options)
+        self.splittable = True
+        self.ibp_intermediate = True
+        self.activation_name = 'SiLU'
+        self.x_min = _SILU_X_MIN
+        self.inflection_left = -_SILU_INFLECTION
+        self.inflection_right = _SILU_INFLECTION
+        self.inflections = [self.inflection_left, self.inflection_right]
+        self.extremes = [self.x_min]
+        self.split_min_gap = 1e-2
+        self.split_range = (self.inflection_left, self.inflection_right)
+
+    def forward(self, x):
+        return F.silu(x)
+
+    def interval_propagate(self, *v):
+        h_L, h_U = v[0][0], v[0][1]
+        y_l = self.forward(h_L)
+        y_u = self.forward(h_U)
+
+        lower = torch.minimum(y_l, y_u)
+        upper = torch.maximum(y_l, y_u)
+
+        x_min = torch.full_like(h_L, self.x_min)
+        y_min = self.forward(x_min)
+        cross_min = torch.logical_and(h_L < self.x_min, h_U > self.x_min)
+        lower = torch.where(cross_min, torch.minimum(lower, y_min), lower)
+        return lower, upper
+
+    def get_split_mask(self, lower, upper, input_index):
+        del input_index
+        return torch.logical_and(
+            upper - lower >= self.split_min_gap,
+            torch.logical_and(
+                upper >= self.split_range[0],
+                lower <= self.split_range[1],
+            ),
+        )
+
+    def _segment_bounds(self, lower, upper):
+        bounds = []
+        left_l = lower
+        left_u = min(upper, self.inflection_left)
+        if left_l <= left_u:
+            bounds.append((left_l, left_u, False))
+
+        mid_l = max(lower, self.inflection_left)
+        mid_u = min(upper, self.inflection_right)
+        if mid_l <= mid_u:
+            bounds.append((mid_l, mid_u, True))
+
+        right_l = max(lower, self.inflection_right)
+        right_u = upper
+        if right_l <= right_u:
+            bounds.append((right_l, right_u, False))
+        return bounds
+
+    def _is_convex_interval(self, lower, upper):
+        return lower >= self.inflection_left and upper <= self.inflection_right
+
+    def _is_concave_interval(self, lower, upper):
+        return upper <= self.inflection_left or lower >= self.inflection_right
+
+    def _find_derivative_root(self, left, right, target, increasing, steps=60):
+        if right - left < 1e-10:
+            return left
+        lo, hi = left, right
+        for _ in range(steps):
+            mid = 0.5 * (lo + hi)
+            value = dsilu(torch.tensor(mid, device=self.device)).item()
+            if increasing:
+                if value < target:
+                    lo = mid
+                else:
+                    hi = mid
+            else:
+                if value > target:
+                    lo = mid
+                else:
+                    hi = mid
+        return 0.5 * (lo + hi)
+
+    def _parallel_tangent_intercept(self, lower, upper, slope, increasing):
+        tangent_point = self._find_derivative_root(
+            lower, upper, slope, increasing=increasing)
+        x_tensor = torch.tensor(tangent_point, device=self.device)
+        return (silu(x_tensor) - slope * x_tensor).item()
+
+    def _derivative_range(self, lower, upper):
+        candidates = [lower, upper]
+        if lower <= self.inflection_left <= upper:
+            candidates.append(self.inflection_left)
+        if lower <= self.inflection_right <= upper:
+            candidates.append(self.inflection_right)
+        values = []
+        for x in candidates:
+            values.append(dsilu(torch.tensor(x, device=self.device)).item())
+        return min(values), max(values)
+
+    def _phi_extrema(self, lower, upper, slope):
+        candidates = [lower, upper]
+        for seg_l, seg_u, increasing in self._segment_bounds(lower, upper):
+            dl = dsilu(torch.tensor(seg_l, device=self.device)).item()
+            du = dsilu(torch.tensor(seg_u, device=self.device)).item()
+            low_d, high_d = (dl, du) if increasing else (du, dl)
+            if low_d - 1e-10 <= slope <= high_d + 1e-10:
+                root = self._find_derivative_root(seg_l, seg_u, slope, increasing)
+                candidates.append(root)
+
+        phi_vals = []
+        for x in candidates:
+            x_tensor = torch.tensor(x, device=self.device)
+            phi_vals.append((silu(x_tensor) - slope * x_tensor).item())
+        return min(phi_vals), max(phi_vals)
+
+    def _optimize_generic_slope(self, lower, upper, initial_slope):
+        deriv_l, deriv_u = self._derivative_range(lower, upper)
+        lo = min(deriv_l, deriv_u)
+        hi = max(deriv_l, deriv_u)
+        if hi - lo < 1e-10:
+            min_phi, max_phi = self._phi_extrema(lower, upper, initial_slope)
+            return initial_slope, min_phi, max_phi
+
+        best_k = initial_slope
+        best_min_phi, best_max_phi = self._phi_extrema(lower, upper, initial_slope)
+        best_gap = best_max_phi - best_min_phi
+
+        search_lo, search_hi = lo, hi
+        for num_steps in (33, 33):
+            step = (search_hi - search_lo) / (num_steps - 1)
+            for idx in range(num_steps):
+                k = search_lo + idx * step
+                min_phi, max_phi = self._phi_extrema(lower, upper, k)
+                gap = max_phi - min_phi
+                if gap < best_gap:
+                    best_gap = gap
+                    best_k = k
+                    best_min_phi = min_phi
+                    best_max_phi = max_phi
+            radius = max(step * 2, 1e-4)
+            search_lo = max(lo, best_k - radius)
+            search_hi = min(hi, best_k + radius)
+
+        return best_k, best_min_phi, best_max_phi
+
+    def bound_relax(self, x, init=False):
+        if init:
+            self.init_linear_relaxation(x)
+
+        lower = x.lower.reshape(-1)
+        upper = x.upper.reshape(-1)
+        lw = torch.empty_like(lower)
+        lb = torch.empty_like(lower)
+        uw = torch.empty_like(lower)
+        ub = torch.empty_like(lower)
+
+        for i in range(lower.numel()):
+            l = lower[i].item()
+            u = upper[i].item()
+            if abs(u - l) < 1e-10:
+                y = silu(torch.tensor(l, device=self.device)).item()
+                lw[i] = uw[i] = 0.0
+                lb[i] = ub[i] = y
+                continue
+
+            y_l = silu(torch.tensor(l, device=self.device)).item()
+            y_u = silu(torch.tensor(u, device=self.device)).item()
+            slope = (y_u - y_l) / (u - l)
+
+            if self._is_convex_interval(l, u):
+                secant_bias = y_l - slope * l
+                tangent_bias = self._parallel_tangent_intercept(
+                    l, u, slope, increasing=True)
+                lw[i] = slope
+                lb[i] = tangent_bias
+                uw[i] = slope
+                ub[i] = secant_bias
+            elif self._is_concave_interval(l, u):
+                secant_bias = y_l - slope * l
+                tangent_bias = self._parallel_tangent_intercept(
+                    l, u, slope, increasing=False)
+                lw[i] = slope
+                lb[i] = secant_bias
+                uw[i] = slope
+                ub[i] = tangent_bias
+            else:
+                slope, min_phi, max_phi = self._optimize_generic_slope(l, u, slope)
+                lw[i] = slope
+                uw[i] = slope
+                lb[i] = min_phi
+                ub[i] = max_phi
+
+        self.lw = lw.view_as(x.lower)
+        self.uw = uw.view_as(x.upper)
+        self.lb = lb.view_as(x.lower)
+        self.ub = ub.view_as(x.upper)
+
+
+class SiLUOp(torch.autograd.Function):
+    @staticmethod
+    def symbolic(g, x):
+        return g.op('custom::SiLU', x).setType(x.type())
+
+    @staticmethod
+    def forward(ctx, x):
+        return F.silu(x)
+
+
+class SiLU(nn.Module):
+    def forward(self, x):
+        return SiLUOp.apply(x)

--- a/tests/test_1d_activation.py
+++ b/tests/test_1d_activation.py
@@ -37,6 +37,20 @@ class GELUOp(torch.autograd.Function):
 def GELU(x):
     return GELUOp.apply(x)
 
+
+class SiLUOp(torch.autograd.Function):
+    @staticmethod
+    def symbolic(g, x):
+        return g.op('custom::SiLU', x)
+
+    @staticmethod
+    def forward(ctx, x):
+        return torch.nn.functional.silu(x)
+
+
+def SiLU(x):
+    return SiLUOp.apply(x)
+
 def gen_hardtanh(min_val, max_val):
    return functools.partial(torch.nn.functional.hardtanh, min_val=min_val, max_val=max_val)
 
@@ -149,7 +163,7 @@ class Test1DActivation(TestCase):
                          torch.sin, torch.cos,
                          torch.tanh, torch.sigmoid, torch.arctan,
                          torch.exp, pow_2, pow_3,
-                         torch.sign, GELU, gen_hardtanh(-1,1),gen_hardtanh(-0.25,0.25),gen_hardtanh(1,10),gen_hardtanh(-5,2),
+                         torch.sign, GELU, SiLU, gen_hardtanh(-1,1),gen_hardtanh(-0.25,0.25),gen_hardtanh(1,10),gen_hardtanh(-5,2),
                          tanhgrad, sigmoidgrad]:
             low, high = -10, 10
             if act_func == torch.reciprocal:

--- a/tests/test_silu.py
+++ b/tests/test_silu.py
@@ -1,0 +1,171 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from auto_LiRPA import BoundedModule, BoundedTensor
+from auto_LiRPA.operators.silu import (
+    SiLU, BoundSiLU, silu, dsilu, d2silu,
+    _SILU_X_MIN, _SILU_INFLECTION,
+)
+from auto_LiRPA.parse_graph import parse_module
+from auto_LiRPA.perturbations import PerturbationLpNorm
+
+
+class SiLUModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.act = SiLU()
+
+    def forward(self, x):
+        return self.act(x)
+
+
+def _bounded_model():
+    model = SiLUModel().eval()
+    x = torch.zeros(1, 1)
+    return BoundedModule(model, x, device='cpu')
+
+
+def _interval_bounds(method, lower, upper):
+    bounded_model = _bounded_model()
+    x_lb = torch.tensor([[lower]], dtype=torch.float32)
+    x_ub = torch.tensor([[upper]], dtype=torch.float32)
+    x_center = (x_lb + x_ub) / 2
+    ptb = PerturbationLpNorm(norm=float('inf'), eps=None, x_L=x_lb, x_U=x_ub)
+    bounded_x = BoundedTensor(x_center, ptb)
+    lb, ub = bounded_model.compute_bounds(x=(bounded_x,), method=method)
+    return lb.item(), ub.item()
+
+
+def _sample_reference(lower, upper, num_samples=50001):
+    xs = torch.linspace(lower, upper, steps=num_samples)
+    ys = F.silu(xs)
+    return ys.min().item(), ys.max().item()
+
+
+def test_silu_custom_module_matches_torch_silu():
+    x = torch.linspace(-8, 8, steps=257)
+    model = SiLUModel().eval()
+    assert torch.allclose(model(x), F.silu(x), atol=1e-7, rtol=1e-7)
+
+
+def test_silu_symbolic_op_is_registered():
+    model = SiLUModel().eval()
+    x = torch.randn(1, 4)
+    ops, _, _, _ = parse_module(model, (x,))
+    assert [node.op for node in ops] == ['custom::SiLU']
+
+
+def test_silu_first_derivative_matches_autograd():
+    x = torch.linspace(-6, 6, steps=101, requires_grad=True)
+    y = F.silu(x)
+    grad = torch.autograd.grad(y.sum(), x)[0]
+    assert torch.allclose(dsilu(x.detach()), grad.detach(), atol=1e-6, rtol=1e-5)
+
+
+def test_silu_second_derivative_matches_autograd():
+    x = torch.linspace(-4, 4, steps=81, requires_grad=True)
+    y = F.silu(x)
+    grad = torch.autograd.grad(y.sum(), x, create_graph=True)[0]
+    grad2 = torch.autograd.grad(grad.sum(), x)[0]
+    assert torch.allclose(d2silu(x.detach()), grad2.detach(), atol=1e-5, rtol=1e-4)
+
+
+def test_silu_known_extreme_and_inflection_points():
+    x_min = torch.tensor(_SILU_X_MIN)
+    inflection = torch.tensor(_SILU_INFLECTION)
+    assert abs(dsilu(x_min).item()) < 1e-6
+    assert abs(d2silu(-inflection).item()) < 1e-6
+    assert abs(d2silu(inflection).item()) < 1e-6
+    assert d2silu(torch.tensor(0.0)).item() > 0
+    assert d2silu(torch.tensor(-3.0)).item() < 0
+    assert d2silu(torch.tensor(3.0)).item() < 0
+
+
+def test_silu_bound_node_split_mask_focuses_on_hard_ranges():
+    node = BoundSiLU(attr={'device': 'cpu'}, inputs=[], output_index=0, options={})
+    lower = torch.tensor([[-6.0, -3.0, 3.0, -0.001]])
+    upper = torch.tensor([[-5.0, 3.0, 5.0, 0.001]])
+    mask = node.get_split_mask(lower, upper, input_index=0)
+    expected = torch.tensor([[False, True, False, False]])
+    assert torch.equal(mask, expected)
+
+
+def test_silu_ibp_uses_internal_minimum():
+    lb, ub = _interval_bounds('IBP', -2.0, 0.0)
+    expected_lb = silu(torch.tensor(_SILU_X_MIN)).item()
+    expected_ub = max(silu(torch.tensor(-2.0)).item(), silu(torch.tensor(0.0)).item())
+    assert abs(lb - expected_lb) < 1e-5
+    assert abs(ub - expected_ub) < 1e-5
+
+
+def test_silu_ibp_matches_monotonic_endpoint_cases():
+    dec_lb, dec_ub = _interval_bounds('IBP', -5.0, -2.0)
+    assert abs(dec_lb - silu(torch.tensor(-2.0)).item()) < 1e-5
+    assert abs(dec_ub - silu(torch.tensor(-5.0)).item()) < 1e-5
+
+    inc_lb, inc_ub = _interval_bounds('IBP', -1.0, 3.0)
+    assert abs(inc_lb - silu(torch.tensor(-1.0)).item()) < 1e-5
+    assert abs(inc_ub - silu(torch.tensor(3.0)).item()) < 1e-5
+
+
+def test_silu_crown_and_ibp_run_on_vector_input():
+    model = SiLUModel().eval()
+    x = torch.randn(1, 8)
+    bounded_model = BoundedModule(model, x, device='cpu')
+    ptb = PerturbationLpNorm(norm=float('inf'), eps=0.1)
+    bounded_x = BoundedTensor(x, ptb)
+
+    for method in ['IBP', 'CROWN']:
+        lb, ub = bounded_model.compute_bounds(x=(bounded_x,), method=method)
+        assert lb.shape == x.shape
+        assert ub.shape == x.shape
+        assert torch.all(lb <= ub)
+
+
+def test_silu_crown_bounds_cover_sampled_truth_on_representative_intervals():
+    intervals = [
+        (-5.0, -3.0),   # concave left
+        (-1.0, 1.0),    # convex middle
+        (3.0, 5.0),     # concave right
+        (-5.0, 5.0),    # cross both inflections
+        (-5.0, 2.0),    # cross minimum and left inflection
+        (-2.5, 2.5),    # cross both inflections tightly
+    ]
+    for lower, upper in intervals:
+        lb, ub = _interval_bounds('CROWN', lower, upper)
+        ref_lb, ref_ub = _sample_reference(lower, upper)
+        assert lb <= ref_lb + 1e-5, (lower, upper, lb, ref_lb)
+        assert ub >= ref_ub - 1e-5, (lower, upper, ub, ref_ub)
+
+
+def test_silu_ibp_bounds_cover_sampled_truth_on_representative_intervals():
+    intervals = [
+        (-5.0, -3.0),
+        (-2.0, 0.0),
+        (-1.0, 1.0),
+        (0.0, 4.0),
+        (-5.0, 5.0),
+    ]
+    for lower, upper in intervals:
+        lb, ub = _interval_bounds('IBP', lower, upper)
+        ref_lb, ref_ub = _sample_reference(lower, upper)
+        assert abs(lb - ref_lb) < 5e-5, (lower, upper, lb, ref_lb)
+        assert abs(ub - ref_ub) < 5e-5, (lower, upper, ub, ref_ub)
+
+
+def test_silu_tiny_interval_is_numerically_stable():
+    center = -0.75
+    radius = 1e-6
+    lb, ub = _interval_bounds('CROWN', center - radius, center + radius)
+    true_value = silu(torch.tensor(center)).item()
+    assert lb <= true_value <= ub
+    assert ub - lb < 1e-4
+
+
+def test_silu_wide_intervals_remain_valid():
+    for lower, upper in [(-20.0, 20.0), (-30.0, -10.0), (10.0, 30.0)]:
+        lb, ub = _interval_bounds('CROWN', lower, upper)
+        ref_lb, ref_ub = _sample_reference(lower, upper, num_samples=20001)
+        assert lb <= ref_lb + 1e-5
+        assert ub >= ref_ub - 1e-5


### PR DESCRIPTION
This PR adds atomic SiLU support to auto_LiRPA.

Changes:
- add a new atomic SiLU operator implementation
- register SiLU in the bound op map
- expose SiLU through operators/__init__.py
- add dedicated SiLU tests
- include SiLU in the 1D activation regression test coverage

Implementation details:
- exact IBP handling using the internal minimum point of SiLU
- tighter linear relaxation on pure convex/concave intervals
- conservative fallback on mixed-curvature intervals
- split hints for harder SiLU intervals

Validation:
- tests/test_silu.py: passed (13 passed)
- tests/test_1d_activation.py: passed (1 passed, 1 skipped; skipped tan test is an existing known issue)
